### PR TITLE
Fix Request instance update on User authentication

### DIFF
--- a/request.go
+++ b/request.go
@@ -20,20 +20,15 @@ var goreq = gorequest.New()
 
 /********** METHODS **********/
 
-func (req *Request) updateRequest(clientID, clientSecret, fingerprint, ipAddress string, authKey ...string) Request {
-	var aKey string
-
+func (req *Request) updateRequest(clientID, clientSecret, fingerprint, ipAddress string, authKey ...string) {
 	if len(authKey) > 0 {
-		aKey = authKey[0]
+		req.authKey = authKey[0]
 	}
 
-	return Request{
-		authKey:      aKey,
-		clientID:     clientID,
-		clientSecret: clientSecret,
-		fingerprint:  fingerprint,
-		ipAddress:    ipAddress,
-	}
+	req.clientID = clientID
+	req.clientSecret = clientSecret
+	req.fingerprint = fingerprint
+	req.ipAddress = ipAddress
 }
 
 /********** REQUEST **********/

--- a/request_mock.go
+++ b/request_mock.go
@@ -23,20 +23,15 @@ var mockResponse = []byte(`{
 
 /********** METHODS **********/
 
-func (req *Request) updateRequest(clientID, clientSecret, fingerprint, ipAddress string, authKey ...string) Request {
-	var aKey string
-
+func (req *Request) updateRequest(clientID, clientSecret, fingerprint, ipAddress string, authKey ...string) {
 	if len(authKey) > 0 {
-		aKey = authKey[0]
+		req.authKey = authKey[0]
 	}
 
-	return Request{
-		authKey:      aKey,
-		clientID:     clientID,
-		clientSecret: clientSecret,
-		fingerprint:  fingerprint,
-		ipAddress:    ipAddress,
-	}
+	req.clientID = clientID
+	req.clientSecret = clientSecret
+	req.fingerprint = fingerprint
+	req.ipAddress = ipAddress
 }
 
 /********** REQUEST **********/

--- a/request_test.go
+++ b/request_test.go
@@ -45,6 +45,31 @@ func createRequestClient() *Request {
 }
 
 /********** TESTS **********/
+func Test_updateRequest(t *testing.T) {
+	assert := assert.New(t)
+	testReq := createRequestClient()
+
+	outdatedReq := *testReq
+	expectedReq := Request{
+		authKey:      "expected_" + testReq.authKey,
+		clientID:     "expected_" + testReq.clientID,
+		clientSecret: "expected_" + testReq.clientSecret,
+		fingerprint:  "expected_" + testReq.fingerprint,
+		ipAddress:    "expected_" + testReq.ipAddress,
+	}
+
+	testReq.updateRequest(
+		expectedReq.clientID,
+		expectedReq.clientSecret,
+		expectedReq.fingerprint,
+		expectedReq.ipAddress,
+		expectedReq.authKey,
+	)
+
+	assert.NotEqual(outdatedReq, *testReq)
+	assert.Equal(expectedReq, *testReq)
+}
+
 func Test_Get(t *testing.T) {
 	assert := assert.New(t)
 	testReq := createRequestClient()

--- a/users_test.go
+++ b/users_test.go
@@ -54,13 +54,21 @@ func createTestUser() *User {
 /********** AUTHENTICATION **********/
 func Test_Authenticate(t *testing.T) {
 	assert := assert.New(t)
-	testUser := createTestUser()
+	var (
+		testUser        = createTestUser()
+		testReq         = testUser.request
+		testFingerprint = "test_fp"
+		testIpAddress   = "127.0.0.1"
+	)
 
 	// No parameters
-	testRes, err := testUser.Authenticate("", "", "")
+	testRes, err := testUser.Authenticate("", testFingerprint, testIpAddress)
 
 	assert.NoError(err)
 	assert.Equal(testRes, mockUsersResponse)
+	assert.NotEqual(testReq, testUser.request)
+	assert.Equal(testFingerprint, testUser.request.fingerprint)
+	assert.Equal(testIpAddress, testUser.request.ipAddress)
 }
 
 func Test_GetRefreshToken(t *testing.T) {


### PR DESCRIPTION
The params `fingerprint` and `ipAddress` received in `User.Authenticate` method are being missed because the new `Request` instance returned by [updateRequest](https://github.com/SynapseFI/SynapseGo/blob/master/users.go#L95) is also being missed.
I think it is not the desired behavior.